### PR TITLE
Add platformio configuration.

### DIFF
--- a/esp-ccs811-bme280-mqtt/esp-ccs811-bme280-mqtt.ino
+++ b/esp-ccs811-bme280-mqtt/esp-ccs811-bme280-mqtt.ino
@@ -76,6 +76,8 @@ float bme280Altitude;
 uint16_t ccs811co2;
 uint16_t ccs811tvoc;
 
+void meassureEnvironment(void);
+
 void setup() {
   Serial.begin(115200);
   Serial.println("Starting up...");
@@ -195,7 +197,7 @@ void loop() {
 
 }
 
-void meassureEnvironment(int) {
+void meassureEnvironment(void) {
   bme280TemperatureC = myBME280.readTempC();;
   bme280Humidity = myBME280.readFloatHumidity();
   bme280Pressure = myBME280.readFloatPressure();

--- a/esp-ccs811-bme280-mqtt/platformio.ini
+++ b/esp-ccs811-bme280-mqtt/platformio.ini
@@ -1,0 +1,25 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:default]
+platform = espressif8266
+board = d1_mini
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+lib_deps =
+  Tasker
+  PubSubClient
+  Adafruit CCS811 Library
+  SparkFun BME280
+


### PR DESCRIPTION
This adds a platformio configuration, allowing you to run the build from the command line, with the toolchain and dependent libraries automatically downloaded and cached. To build:
  pio run
To build and upload to the board
  pio run -t upload

Note: I have not actually tried the resulting binary on a board, but at least it compiles fine.